### PR TITLE
Bugfix: Analysis of derived observables is now implemented

### DIFF
--- a/src/StatisticalAnalysis/bootstrap.py
+++ b/src/StatisticalAnalysis/bootstrap.py
@@ -1,16 +1,19 @@
-"""
+r"""
+    This file contains the
+        * Bootstrap
+    method.
 """
 import numpy as np
-from numpy import average
+from .jackknife import _leave_n_out_ran
 
-def _leave_out(t_data,t_num_ran_indices):
+def _leave_out(t_data,t_num_subdata_sets):
     """
         t_data: numpy.ndarray
-            Data which becomes bootstraped. It is assumed that axis = 0
-            represents the different data points in the set and all other axis'
-            account for the dimensionality of the estimator.
-        t_num_leave_outs: int
-            Defines how many subdata sets are created by bootstrap.
+            Data array, containing the raw data. It is assumed,
+            that axis=0 represents the data points of the method and subsequent
+            axis' are assumed to represent multidimensional estimators.
+        t_num_subdata_sets: int
+            List of random indices which are left out.
 
         Returns:
             A set of subdata where each subdata is the original data set but without
@@ -19,95 +22,101 @@ def _leave_out(t_data,t_num_ran_indices):
     # The bootstrap methods leaves 1 randomly chosen data point out.
     # Following function can be recycled for this pupose. Therefore, the
     # default case t_n = 1 is used.
-    from qcdanalysistools.jackknife import _leave_n_out_ran
-    return _leave_n_out_ran(t_data,t_num_ran_indices,t_n=1)
+    return _leave_n_out_ran(t_data,t_num_subdata_sets,t_n=1)
 
-def bootstrap_est(t_data,t_num_leave_outs):
+def bootstrap_est(t_data,t_num_subdata_sets = None,t_obs=np.average,**obs_kwargs):
     """
         t_data: numpy.ndarray
-            Data which becomes bootstraped. It is assumed that axis = 0
-            represents the different data points in the set and all other axis'
-            account for the dimensionality of the estimator.
-        t_num_leave_outs: int
-            Defines how many subdata sets are created by bootstrap.
+            Data array, containing the raw data. It is assumed,
+            that axis=0 represents the data points of the method and subsequent
+            axis' are assumed to represent multidimensional estimators.
+        t_num_ran_indices: int, default: None
+            Number of random datasets created by leave one random out. Defaults
+            to t_data.shape[0] // 2 if None is given.
+        t_obs: function, default: numpy.average
+            Observable which should be computed over t_data.
+        **obs_kwargs: keyworded arguments
+            Keyworded arguments passed to t_obs
 
         Returns: numpy.ndarray
-            Variance after bootstrapping for each dimension of the estimator. Let
-            d be the total dimension of the estimator, n_i denotes the number
-            of elements in that particular dimension.
-                var.shape = (n_1,n_2,...,n_d) = t_data.shape[1:]
+            Estimator
 
-        This functions leaves a data point, which is chosen randomly, out (bootstrap)
-        Then, the estimator (numpy.average) on each of these subdata sets is evaluated.
-        The variance is determined by
-            var = 1/N sum_{k=1}^K (Theta_k - Theta)^2
-        where N is the data size, Theta_k is the estimator on the kth subdata set
-        and
-            Theta = 1/K sum_{k=1}^K Theta_k
+        This function uses the bootstrap method to determine the estimator of the
+        observable determined over t_data.
+        Let $N$ be the size of the data set. Let $X = {x_i}_{i\in[N]}$ denote
+        the total data set and K be the number of subdata_sets
+            1. On data X perform leave one random out --> ${X_k}_{k\in[0,K-1]}$
+            2. Compute observable on each subdata set --> $\Theta_k=\Theta(X_k)$
+            3. Compute estimator                      --> $\tilde{\Theta} = \frac{1}{K} \sum_{k\in[0,K-1]} \Theta_k$
+            4. Return $\tilde{\Theta}$
     """
-    # create subdata sets
-    t_num_ran_indices = t_data.shape[0]//2 if t_num_ran_indices==None else t_num_ran_indices
-    subdata_sets = _leave_out(t_data,t_num_ran_indices=t_num_leave_outs)
+    # 1. create subdata sets
+    t_num_subdata_sets = t_data.shape[0]//2 if t_num_subdata_sets==None else t_num_subdata_sets
+    subdata_sets = _leave_out(t_data,t_num_subdata_sets=t_num_subdata_sets)
 
-    # determine and return the estimator
-    # the first (inner) average, averages in each block, the second (outer) does
-    # over the subdata sets, for index details see jackknife._leave_n_out_ran
-    # documentation.
-    return np.average(np.average(subdata_sets, axis = 1), axis = 0)
+    # 2. Compute observables
+    Theta_k = np.zeros( shape = (t_num_subdata_sets,*t_data.shape[1:]) )
+    for k,x_k in enumerate(subdata_sets):
+        Theta_k[k] = t_obs(x_k,**obs_kwargs)
 
-def bootstrap_var(t_data,t_num_leave_outs):
-    """
+    # 3. determine estimator
+    return np.average(Theta_k, axis = 0)
+
+def bootstrap_var(t_data,t_num_subdata_sets = None,t_obs=np.average,**obs_kwargs):
+    r"""
         t_data: numpy.ndarray
-            Data which becomes bootstraped. It is assumed that axis = 0
-            represents the different data points in the set and all other axis'
-            account for the dimensionality of the estimator.
-        t_num_leave_outs: int
-            Defines how many subdata sets are created by bootstrap.
+            Data array, containing the raw data. It is assumed,
+            that axis=0 represents the data points of the method and subsequent
+            axis' are assumed to represent multidimensional estimators.
+        t_num_subdata_sets: int, default: None
+            Number of random datasets created by leave one random out. Defaults
+            to t_data.shape[0] // 2 if None is given.
+        t_obs: function, default: numpy.average
+            Observable which should be computed over t_data.
+        **obs_kwargs: keyworded arguments
+            Keyworded arguments passed to t_obs
 
         Returns: numpy.ndarray
-            Variance after bootstrapping for each dimension of the estimator. Let
-            d be the total dimension of the estimator, n_i denotes the number
-            of elements in that particular dimension.
-                var.shape = (n_1,n_2,...,n_d) = t_data.shape[1:]
+            Variance
 
-        This functions leaves a data point, which is chosen randomly, out (bootstrap)
-        Then, the estimator (numpy.average) on each of these subdata sets is evaluated.
-        The variance is determined by
-            var = 1/N sum_{k=1}^K (Theta_k - Theta)^2
-        where N is the data size, Theta_k is the estimator on the kth subdata set
-        and
-            Theta = 1/K sum_{k=1}^K Theta_k
+        This function uses the bootstrap method to determine the estimator of the
+        observable determined over t_data.
+        Let $N$ be the size of the data set. Let $X = {x_i}_{i\in[N]}$ denote
+        the total data set and K be the number of subdata sets
+            1. On data X perform leave one random out --> ${X_k}_{k\in[0,N-1]}$
+            2. Compute observable on each subdata set --> $\Theta_k=\Theta(X_k)$
+            3. Compute estimator                      --> $\tilde{Theta} = \frac{1}{K}\sum_{k\in[0,K-1]} \Theta_k$
+            4. Compute variance                       --> $\sigma^2 = \frac{1}{K} \sum_{k\in[0,K-1]} \left(\Theta_k-\tilde{\Theta}\right)^2$
     """
-    # create subdata sets
-    t_num_ran_indices = t_data.shape[0]//2 if t_num_ran_indices==None else t_num_ran_indices
-    subdata_sets = _leave_out(t_data,t_num_ran_indices=t_num_leave_outs)
+    # 1. create subdata sets
+    t_num_subdata_sets = t_data.shape[0]//2 if t_num_subdata_sets==None else t_num_subdata_sets
+    subdata_sets = _leave_out(t_data,t_num_subdata_sets=t_num_subdata_sets)
 
-    # average in each block for index details see jackknife._leave_n_out_ran
-    # documentation.
-    return np.var( np.average( subdata_sets, axis = 1 ), axis = 0 )
+    # 2. Compute observables
+    Theta_k = np.zeros( shape = (t_num_subdata_sets,*t_data.shape[1:]) )
+    for k,x_k in enumerate(subdata_sets):
+        Theta_k[k] = t_obs(x_k,**obs_kwargs)
 
-def bootstrap(t_data,t_num_leave_outs, t_blocked = False, t_num_blocks = None):
-    """
+    # 3,4. determine variance
+    return np.var(Theta_k, axis = 0)
+
+
+def bootstrap(t_data,t_num_subdata_sets = None, t_obs = np.average, t_blocked = False, t_num_blocks = None, **obs_kwargs):
+    r"""
         t_data: numpy.ndarray
-            Data array, containing the raw data of an observable or raw data on
-            which t_avg must be called. It is assumed, that axis=0 represents
-            the data points of the method and subsequent axis' are assumed to
-            represent multidimensional estimators.
-        t_num_leave_outs: int
-            Defines how many subdata sets are created by bootstrap.
-        t_blocked: bool, default: False
-            Set to `True` if the Bootstrap should be combined with the blocking
-            method i.e.
-                * t_data is blocked into t_num_blocks subdata blocks
-                * On each subblock a bootstrap is performed
-                * A simple average of the bootstrap estimators and variances is returned
-            In that case `t_num_blocks` must not be `None`!
-        t_num_blocks: int, list of ints
-            An integer which defines the number of blocks in which t_data is blocked
-            once the blocking method is applied.
+            Data array, containing the raw data. It is assumed,
+            that axis=0 represents the data points of the method and subsequent
+            axis' are assumed to represent multidimensional estimators.
+        t_num_subdata_sets: int, default: None
+            Number of random datasets created by leave one random out. Defaults
+            to t_data.shape[0] // 2 if None is given.
+        t_obs: function, default: numpy.average
+            Observable which should be computed over t_data.
+        **obs_kwargs: keyworded arguments
+            Keyworded arguments passed to t_obs
 
-        Returns: numpy.ndarray, numpy.ndarray
-            estimator, variance
+        Returns: numpy.ndarray
+            Estimator,Variance
     """
     # define return values
     est = None
@@ -120,17 +129,17 @@ def bootstrap(t_data,t_num_leave_outs, t_blocked = False, t_num_blocks = None):
         l_var = [None]*t_num_blocks
 
         for block_id in range(0,t_num_blocks):
-            l_est[block_id] = bootstrap_est(blocking.get_block(t_data,block_id,block_size),t_num_leave_outs=t_num_leave_outs)
-            l_var[block_id] = bootstrap_var(blocking.get_block(t_data,block_id,block_size),t_num_leave_outs=t_num_leave_outs)
+            l_est[block_id] = bootstrap_est(blocking.get_block(t_data,block_id,block_size),t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
+            l_var[block_id] = bootstrap_var(blocking.get_block(t_data,block_id,block_size),t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
 
-        l_est[t_num_blocks-1] = bootstrap_est(blocking.get_block(t_data,t_num_blocks-1,block_size),t_num_leave_outs=t_num_leave_outs)
-        l_var[t_num_blocks-1] = bootstrap_var(blocking.get_block(t_data,t_num_blocks-1,block_size),t_num_leave_outs=t_num_leave_outs)
+        l_est[t_num_blocks-1] = bootstrap_est(blocking.get_block(t_data,t_num_blocks-1,block_size),t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
+        l_var[t_num_blocks-1] = bootstrap_var(blocking.get_block(t_data,t_num_blocks-1,block_size),t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
 
         est = np.average(l_est,axis=0)
         var = np.average(l_var,axis=0)
     else:
         # simple leave n out (randomnized)
-        est = bootstrap_est(t_data,t_num_leave_outs=t_num_leave_outs)
-        var = bootstrap_var(t_data,t_num_leave_outs=t_num_leave_outs)
+        est = bootstrap_est(t_data,t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
+        var = bootstrap_var(t_data,t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
 
     return est,var

--- a/src/StatisticalAnalysis/bootstrap.py
+++ b/src/StatisticalAnalysis/bootstrap.py
@@ -100,7 +100,6 @@ def bootstrap_var(t_data,t_num_subdata_sets = None,t_obs=np.average,**obs_kwargs
     # 3,4. determine variance
     return np.var(Theta_k, axis = 0)
 
-
 def bootstrap(t_data,t_num_subdata_sets = None, t_obs = np.average, t_blocked = False, t_num_blocks = None, **obs_kwargs):
     r"""
         t_data: numpy.ndarray
@@ -129,17 +128,17 @@ def bootstrap(t_data,t_num_subdata_sets = None, t_obs = np.average, t_blocked = 
         l_var = [None]*t_num_blocks
 
         for block_id in range(0,t_num_blocks):
-            l_est[block_id] = bootstrap_est(blocking.get_block(t_data,block_id,block_size),t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
-            l_var[block_id] = bootstrap_var(blocking.get_block(t_data,block_id,block_size),t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
+            l_est[block_id] = bootstrap_est(blocking.get_block(t_data,block_id,block_size),t_num_subdata_sets=t_num_subdata_sets,t_obs=t_obs,**obs_kwargs)
+            l_var[block_id] = bootstrap_var(blocking.get_block(t_data,block_id,block_size),t_num_subdata_sets=t_num_subdata_sets,t_obs=t_obs,**obs_kwargs)
 
-        l_est[t_num_blocks-1] = bootstrap_est(blocking.get_block(t_data,t_num_blocks-1,block_size),t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
-        l_var[t_num_blocks-1] = bootstrap_var(blocking.get_block(t_data,t_num_blocks-1,block_size),t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
+        l_est[t_num_blocks-1] = bootstrap_est(blocking.get_block(t_data,t_num_blocks-1,block_size),t_num_subdata_sets=t_num_subdata_sets,t_obs=t_obs,**obs_kwargs)
+        l_var[t_num_blocks-1] = bootstrap_var(blocking.get_block(t_data,t_num_blocks-1,block_size),t_num_subdata_sets=t_num_subdata_sets,t_obs=t_obs,**obs_kwargs)
 
         est = np.average(l_est,axis=0)
         var = np.average(l_var,axis=0)
     else:
         # simple leave n out (randomnized)
-        est = bootstrap_est(t_data,t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
-        var = bootstrap_var(t_data,t_num_leave_outs=t_num_leave_outs,t_obs=t_obs,**obs_kwargs)
+        est = bootstrap_est(t_data,t_num_subdata_sets=t_num_subdata_sets,t_obs=t_obs,**obs_kwargs)
+        var = bootstrap_var(t_data,t_num_subdata_sets=t_num_subdata_sets,t_obs=t_obs,**obs_kwargs)
 
     return est,var

--- a/src/StatisticalAnalysis/jackknife.py
+++ b/src/StatisticalAnalysis/jackknife.py
@@ -180,7 +180,7 @@ def jackknife_var(t_data, t_obs = np.average, t_n = 1, t_random_leaveout = False
             Keyworded arguments passed to t_obs
 
         Returns: numpy.ndarray
-            Estimator
+            Variance
 
         This functions uses the leave n out jackknife method in order to determine
         the estimator of the observable determined over t_data.

--- a/src/StatisticalAnalysis/jackknife.py
+++ b/src/StatisticalAnalysis/jackknife.py
@@ -257,17 +257,17 @@ def jackknife(t_data, t_obs = np.average, t_n = 1,  t_random_leaveout = False, t
         l_var = [None]*t_num_blocks
 
         for block_id in range(0,t_num_blocks):
-            l_est[block_id] = jackknife_est(blocking.get_block(t_data,block_id,block_size), t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices)
-            l_var[block_id] = jackknife_var(blocking.get_block(t_data,block_id,block_size), t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices)
+            l_est[block_id] = jackknife_est(blocking.get_block(t_data,block_id,block_size), t_obs=t_obs, t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices,**obs_kwargs)
+            l_var[block_id] = jackknife_var(blocking.get_block(t_data,block_id,block_size), t_obs=t_obs, t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices,**obs_kwargs)
 
-        l_est[t_num_blocks-1] = jackknife_est(blocking.get_block(t_data,t_num_blocks-1,block_size,t_is_end=True), t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices)
-        l_var[t_num_blocks-1] = jackknife_var(blocking.get_block(t_data,t_num_blocks-1,block_size,t_is_end=True), t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices)
+        l_est[t_num_blocks-1] = jackknife_est(blocking.get_block(t_data,t_num_blocks-1,block_size,t_is_end=True),t_obs=t_obs, t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices,**obs_kwargs)
+        l_var[t_num_blocks-1] = jackknife_var(blocking.get_block(t_data,t_num_blocks-1,block_size,t_is_end=True),t_obs=t_obs, t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices,**obs_kwargs)
 
         est = np.average(l_est,axis=0)
         var = np.average(l_var,axis=0)
     else:
         # simple leave n out (randomnized)
-        est = jackknife_est(t_data, t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices)
-        var = jackknife_var(t_data, t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices)
+        est = jackknife_est(t_data, t_obs=t_obs, t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices,**obs_kwargs)
+        var = jackknife_var(t_data, t_obs=t_obs, t_n = t_n, t_random_leaveout = t_random_leaveout, t_num_ran_indices = t_num_ran_indices,**obs_kwargs)
 
     return est,var

--- a/src/StatisticalAnalysis/jackknife.py
+++ b/src/StatisticalAnalysis/jackknife.py
@@ -1,16 +1,15 @@
-"""
+r"""
     This file contains the
         * leave n out jackknife
         * leave n random out jackknife
     methods.
 """
 import numpy as np
-from numpy import average
 
 def _leave_n_out(t_data, t_n = 1):
-    """
+    r"""
         t_data: numpy.ndarray
-            Data array, containing the raw data of an observable. It is assumed,
+            Data array, containing the raw data. It is assumed,
             that axis=0 represents the data points of the method and subsequent
             axis' are assumed to represent multidimensional estimators.
         t_n: int, default: 1
@@ -38,22 +37,23 @@ def _leave_n_out(t_data, t_n = 1):
                 t_data.shape[1:]
 
     """
+    # initialize tensor over subdata sets
     subdata_sets = np.zeros( shape=( t_data.shape[0]//t_n, t_data.shape[0]-t_n, *t_data.shape[1:] ) )
 
     for k in range(t_data.shape[0]//t_n):
+        # delete t_n from the full data block and store it in the subdata matrix
         subdata_sets[k] = np.delete(
             t_data,
             [ k+i if k+i < t_data.shape[0] else i for i in range(t_n) ],
             axis = 0,
         )
 
-
     return subdata_sets
 
 def _leave_n_out_ran(t_data,t_num_ran_indices,t_n=1):
-    """
+    r"""
         t_data: numpy.ndarray
-            Data array, containing the raw data of an observable. It is assumed,
+            Data array, containing the raw data. It is assumed,
             that axis=0 represents the data points of the method and subsequent
             axis' are assumed to represent multidimensional estimators.
         t_num_ran_indices: int, default: None
@@ -84,11 +84,16 @@ def _leave_n_out_ran(t_data,t_num_ran_indices,t_n=1):
                 t_data.shape[1:]
     """
 
+    # initialize tensor over subdata sets
     subdata_sets = np.zeros( shape=( t_num_ran_indices, t_data.shape[0]-t_n, *t_data.shape[1:] ) )
 
+    # draw indices which should be left out
     leave_out_index_list = np.random.randint(0,high=t_data.shape[0]-1,size=t_num_ran_indices)
 
     for k in range(len(leave_out_index_list)):
+
+        # delete t_n from the full data block started at a random index k and
+        # store it in the subdata matrix
         subdata_sets[k] = np.delete(
             t_data,
             [ leave_out_index_list[k]+i if leave_out_index_list[k]+i < t_data.shape[0] else i for i in range(t_n) ],
@@ -97,12 +102,14 @@ def _leave_n_out_ran(t_data,t_num_ran_indices,t_n=1):
 
     return subdata_sets
 
-def jackknife_est(t_data, t_n = 1, t_random_leaveout = False, t_num_ran_indices=None):
-    """
+def jackknife_est(t_data, t_n = 1, t_obs = np.average, t_random_leaveout = False, t_num_ran_indices=None, **obs_kwargs):
+    r"""
         t_data: numpy.ndarray
-            Data array, containing the raw data of an observable. It is assumed,
+            Data array, containing the raw data. It is assumed,
             that axis=0 represents the data points of the method and subsequent
             axis' are assumed to represent multidimensional estimators.
+        t_obs: function, default: numpy.average
+            Observable which should be computed over t_data.
         t_n: int, default: 1
             Size of leave n out method.
         t_random_leaveout: bool, default: False
@@ -111,42 +118,56 @@ def jackknife_est(t_data, t_n = 1, t_random_leaveout = False, t_num_ran_indices=
         t_num_ran_indices: int, default: None
             Defines the number of random indices drawn in the random leave out
             method. If default is used it is determined to half data size.
+        **obs_kwargs: keyworded arguments
+            Keyworded arguments passed to t_obs
 
         Returns: numpy.ndarray
             Estimator
 
         This functions uses the leave n out jackknife method in order to determine
-        the estimator of the data set t_data. Let N be the size of the data set
-        and K be the number of subdata sets. Let
-            Theta = 1/N sum_{n=1}^N x
-        be the estimator on the total data set with data points x and Theta_k the
-        one on the kth subdata set. Then the returned estimator is biased
-        improved by
-            N * Theta - (N-1) * 1/K sum_{k=1}^K Theta_k
+        the estimator of the observable determined over t_data.
+        Let $N$ be the size of the data set and $K = \frac{N}{t_n}$ be the number
+        of subdata sets. Let $X = {x_i}_{i\in[N]}$ denote the total data set
+            1. Compute Observable on Dataset          --> $\hat{\Theta}=\Theta(X)$
+            2. On data X perform a leave n out method --> ${X_k}_{k\in[0,K-1]}$
+            3. Compute observable on each subdata set --> $\Theta_k=\Theta(X_k)$
+            4. Compute biased estimator               --> $\tilde{\Theta} = \frac{1}{K} \sum_{k\in[0,K-1]} \Theta_k$
+            5. Compute biasimproved estimator         --> $\Theta_{est} = \hat{\Theta} - (K-1) (\tilde{\Theta} - \hat{\Theta})$
+            6. Return $\Theta_{est}$
     """
+    # 1. determine the estimator on the full data set
+    Theta_hat = t_obs(t_data,**obs_kwargs)
 
-    # determine the estimator on the full data set
-    global_est = np.average(t_data, axis = 0)
-
-    # create leave n out data sets
+    # 2. create leave n out data sets
     if t_random_leaveout:
         t_num_ran_indices = t_data.shape[0]//2 if t_num_ran_indices is None else t_num_ran_indices
-        subdata_sets = _leave_n_out_ran(t_data,t_num_ran_indices=t_num_ran_indices, t_n = t_n)
+        subdata_sets = _leave_n_out_ran(t_data,t_num_ran_indices=t_num_ran_indices, t_n = t_n,)
     else:
         subdata_sets = _leave_n_out(t_data, t_n = t_n)
+
+    K = subdata_sets.shape[0]
+
+    # 3. Compute observables
+    Theta_k = np.zeros( shape = (K,*t_data.shape[1:]) )
+    for k,x_k in enumerate(subdata_sets):
+        Theta_k[k] = t_obs(x_k,**obs_kwargs)
+
+    # 4.
+    Theta_tilde = np.average(Theta_k,axis=0)
 
     # determine and return the bias reduced estimator
     # the first (inner) average, averages in each block, the second (outer) does
     # over the subdata sets, for index details see _leave_n_out(_ran) documentation.
-    return t_data.shape[0] * global_est \
-         -(t_data.shape[0]-1) * np.average(np.average(subdata_sets,axis = 1),axis=0)
+    return K * Theta_hat -(K-1) * Theta_tilde
 
-def jackknife_var(t_data, t_n = 1, t_random_leaveout = False, t_num_ran_indices = None):
-    """
+def jackknife_var(t_data, t_obs = np.average, t_n = 1, t_random_leaveout = False, t_num_ran_indices = None,**obs_kwargs):
+    r"""
         t_data: numpy.ndarray
-            Data array, containing the raw data of an observable. It is assumed,
+            Data array, containing the raw data. It is assumed,
             that axis=0 represents the data points of the method and subsequent
             axis' are assumed to represent multidimensional estimators.
+        t_obs: function, default: numpy.average
+            Observable which should be computed over t_data.
         t_n: int, default: 1
             Size of leave n out method.
         t_random_leaveout: bool, default: False
@@ -155,41 +176,51 @@ def jackknife_var(t_data, t_n = 1, t_random_leaveout = False, t_num_ran_indices 
         t_num_ran_indices: int, default: None
             Defines the number of random indices drawn in the random leave out
             method. If default is used it is determined to half data size.
+        **obs_kwargs: keyworded arguments
+            Keyworded arguments passed to t_obs
 
         Returns: numpy.ndarray
-            variance
+            Estimator
 
         This functions uses the leave n out jackknife method in order to determine
-        the variance of the data set t_data. Let N be the size of the data set and
-        K be the number of subdata sets
-            var = (N-1)/N * sum_{k=1}^K (Theta_k - Theta)^2
-        where Theta_k is the estimator on the kth subdata set and
-            Theta = 1/N sum_{n=1}^N x
-        is the estimator on the total data set with data points x.
+        the estimator of the observable determined over t_data.
+        Let $N$ be the size of the data set and $K = \frac{N}{t_n}$ be the number
+        of subdata sets. Let $X = {x_i}_{i\in[N]}$ denote the total data set
+            1. Compute Observable on Dataset          --> $\hat{\Theta}=\Theta(X)$
+            2. On data X perform a leave n out method --> ${X_k}_{k\in[0,K-1]}$
+            3. Compute observable on each subdata set --> $\Theta_k=\Theta(X_k)$
+            4. Compute variance                       --> $\sigma^2 = \frac{K-1}{K} \sum_{k\in[0,K-1]} \left( \Theta_k - \hat{\Theta} \right)^2$
+            6. Return $\sigma^2$
     """
 
-    # determine the estimator on the full data set
-    global_est = np.average(t_data, axis = 0)
+    # 1. determine the estimator on the full data set
+    Theta_hat = t_obs(t_data, **obs_kwargs)
 
-    # create leave n out data sets
+    # 2. create leave n out data sets
     if t_random_leaveout:
         t_num_ran_indices = t_data.shape[0]//2 if t_num_ran_indices is None else t_num_ran_indices
         subdata_sets = _leave_n_out_ran(t_data,t_num_ran_indices=t_num_ran_indices, t_n = t_n)
     else:
         subdata_sets = _leave_n_out(t_data, t_n = t_n)
 
-    # determine estimator on each subdata set
-    est = np.average(subdata_sets, axis=0)
+    K = subdata_sets.shape[0]
+
+    # 3. Compute observables
+    Theta_k = np.zeros( shape = (K,*t_data.shape[1:]) )
+    for k,x_k in enumerate(subdata_sets):
+        Theta_k[k] = t_obs(x_k,**obs_kwargs)
 
     # determine variance
-    return ((t_data.shape[0]-1)/t_data.shape[0]) * np.sum( np.square(est-global_est), axis = 0 )
+    return ((K-1)/K) * np.sum( np.square(Theta_k-Theta_hat), axis = 0 )
 
-def jackknife(t_data, t_n = 1, t_random_leaveout = False, t_num_ran_indices=None, t_blocked = False, t_num_blocks = None):
-    """
+def jackknife(t_data, t_obs = np.average, t_n = 1,  t_random_leaveout = False, t_num_ran_indices=None, t_blocked = False, t_num_blocks = None,**obs_kwargs):
+    r"""
         t_data: numpy.ndarray
             Data array, containing the raw data of an observable. It is assumed,
             that axis=0 represents the data points of the method and subsequent
             axis' are assumed to represent multidimensional estimators.
+        t_obs: function, default: numpy.average
+            Observable which should be computed over t_data
         t_n: int, default: 1
             Size of leave n out method.
         t_random_leaveout: bool, default: False

--- a/test/t_blocking.py
+++ b/test/t_blocking.py
@@ -1,0 +1,86 @@
+import numpy as np
+
+import qcdanalysistools.analysis as ana
+
+do_print = True
+
+data_shape = (102,12)
+num_blocks = 10
+
+def test_estimator():
+    # define trivial observable
+    def obs(x,alpha=2):
+        return np.power(np.average(x,axis=0),alpha)
+
+    test_data = np.ones( shape=data_shape )
+    vali_data = 1 #np.ones(  )
+
+    res = ana.blocking_est(
+        test_data,
+        t_obs = obs,
+        t_num_blocks = num_blocks,
+        alpha=20
+    )
+
+    if do_print:
+        print("Test data:",test_data)
+        print("Result   :",res)
+        print("Valid res:",vali_data - res)
+
+    if np.all(vali_data == res):
+        print("Estimator Works")
+
+def test_variance():
+    # define trivial observable
+    def obs(x,alpha=2):
+        return np.power(np.average(x,axis=0),alpha)
+
+    test_data = np.ones( shape=data_shape )
+    vali_data = 0
+
+    res = ana.blocking_var(
+        test_data,
+        t_obs = obs,
+        t_num_blocks = num_blocks,
+        alpha=20
+    )
+
+    if do_print:
+        print("Test data:",test_data)
+        print("Result   :",res)
+        print("Valid res:",vali_data - res)
+
+    if np.all(vali_data == res):
+        print("Variance Works")
+
+def test_jackknife():
+    # define trivial observable
+    def obs(x,alpha=2):
+        return np.power(np.average(x,axis=0),alpha)
+
+    test_data = np.ones( shape=data_shape )
+    vali_var = 0
+    vali_est = 1
+
+    est,var = ana.blocking(
+        test_data,
+        t_obs = obs,
+        t_num_blocks = num_blocks,
+        alpha=20
+    )
+
+    if do_print:
+        print("Test data:",test_data)
+        print("Estimator:",est)
+        print("Variance :",var)
+        print("ValidateE:",vali_est-est)
+        print("ValidateV:",vali_var-var)
+
+    if np.all(vali_est == est) and np.all(vali_var == var):
+        print("Blocking Works")
+
+test_estimator()
+print("")
+test_variance()
+print("")
+test_jackknife()

--- a/test/t_bootstrap.py
+++ b/test/t_bootstrap.py
@@ -1,0 +1,88 @@
+import numpy as np
+
+import qcdanalysistools.analysis as ana
+
+do_print = True
+
+data_shape = (102,12)
+
+def test_estimator():
+    def obs(x,alpha=2):
+        return np.power(np.average(x,axis=0),alpha)
+
+    test_data = np.ones( shape=data_shape )
+    vali_data = 1
+
+    res = ana.bootstrap_est(
+        test_data,
+        t_num_subdata_sets = 50,
+        t_obs = obs,
+        alpha=20
+    )
+
+    if do_print:
+        print("Test data:",test_data)
+        print("Result   :",res)
+        print("Valid res:",vali_data - res)
+
+    if np.all(vali_data == res):
+        print("Estimator Works")
+
+def test_variance():
+
+    def obs(x,alpha=2):
+        return np.power(np.average(x,axis=0),alpha)
+
+    test_data = np.ones( shape=data_shape )
+    vali_data = 0
+
+    res = ana.bootstrap_var(
+        test_data,
+        t_num_subdata_sets = 50,
+        t_obs = obs,
+        alpha=20
+    )
+
+    if do_print:
+        print("Test data:",test_data)
+        print("Result   :",res)
+        print("Valid res:",vali_data - res)
+
+    if np.all(vali_data == res):
+        print("Variance Works")
+
+def test_jackknife():
+    # define trivial observable
+    def obs(x,alpha=2):
+        return np.power(np.average(x,axis=0),alpha)
+
+    test_data = np.ones( shape=data_shape )
+    vali_var = 0
+    vali_est = 1
+
+    est,var = ana.jackknife(
+        test_data,
+        t_obs = obs,
+        t_n = 1,
+        t_random_leaveout = False,
+        t_num_ran_indices = 20,
+        t_blocked = False,
+        t_num_blocks = True,
+        alpha=20
+    )
+
+    if do_print:
+        print("Test data:",test_data)
+        print("Estimator:",est)
+        print("Variance :",var)
+        print("ValidateE:",vali_est-est)
+        print("ValidateV:",vali_var-var)
+
+    if np.all(vali_est == est) and np.all(vali_var == var):
+        print("Bootstrap Works")
+
+test_estimator()
+print("")
+test_variance()
+print("")
+test_jackknife()

--- a/test/t_jackknife.py
+++ b/test/t_jackknife.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+import qcdanalysistools.analysis as ana
+
+do_print = True
+
+data_shape = (102,12)
+
+def test_estimator():
+    # define trivial observable
+    def obs(x,alpha=2):
+        return np.power(np.average(x,axis=0),alpha)
+
+    test_data = np.ones( shape=data_shape )
+    vali_data = 1 #np.ones(  )
+
+    res = ana.jackknife_est(
+        test_data,
+        t_n = 10,
+        t_obs = obs,
+        t_random_leaveout = True,
+        t_num_ran_indices = 20,
+        alpha=20
+    )
+
+    if do_print:
+        print("Test data:",test_data)
+        print("Result   :",res)
+        print("Valid res:",vali_data - res)
+
+    if np.all(vali_data == res):
+        print("Estimator Works")
+
+def test_variance():
+    # define trivial observable
+    def obs(x,alpha=2):
+        return np.power(np.average(x,axis=0),alpha)
+
+    test_data = np.ones( shape=data_shape )
+    vali_data = 0
+
+    res = ana.jackknife_var(
+        test_data,
+        t_n = 1,
+        t_obs = obs,
+        t_random_leaveout = False,
+        t_num_ran_indices = 20,
+        alpha=20
+    )
+
+    if do_print:
+        print("Test data:",test_data)
+        print("Result   :",res)
+        print("Valid res:",vali_data - res)
+
+    if np.all(vali_data == res):
+        print("Variance Works")
+
+def test_jackknife():
+    # define trivial observable
+    def obs(x,alpha=2):
+        return np.power(np.average(x,axis=0),alpha)
+
+    test_data = np.ones( shape=data_shape )
+    vali_var = 0
+    vali_est = 1
+
+    est,var = ana.jackknife(
+        test_data,
+        t_obs = obs,
+        t_n = 1,
+        t_random_leaveout = False,
+        t_num_ran_indices = 20,
+        t_blocked = False,
+        t_num_blocks = True,
+        alpha=20
+    )
+
+    if do_print:
+        print("Test data:",test_data)
+        print("Estimator:",est)
+        print("Variance :",var)
+        print("ValidateE:",vali_est-est)
+        print("ValidateV:",vali_var-var)
+
+    if np.all(vali_est == est) and np.all(vali_var == var):
+        print("Jackknife Works")
+
+test_estimator()
+print("")
+test_variance()
+print("")
+test_jackknife()


### PR DESCRIPTION
The Analysis methods
* Jackknife
* Bootstrap
* Blocking

now have a new parameter `t_obs = np.average`. This is a function which is called in the process of computing a derived observable estimator represented by `t_obs`. The computation of effective mass is adjusted. 
Note the Code is now much slower, obviously. Might need to think about a faster interface! 